### PR TITLE
feat: explore wikipedia links in starfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,21 @@
-# WordSpace • Semantic Starfield
+# StarWiki • Wikipedia Rabbit Hole Explorer
 
-## What it is
-An interactive "word universe" where you explore meaning by moving from one word to its nearest meanings—and a few intentionally far-off contrasts. It’s like flying through a semantic starfield: every word becomes a small galaxy of related ideas.
+StarWiki is an interactive starfield that lets you drift through Wikipedia one link at a time.  Each page is drawn as the centre of a tiny universe with up to twenty outgoing article links orbiting around it.  Click any ray to fly to the linked page and continue the journey.
 
-## Core use
-- **Start anywhere.** Type a word to place it at the center.
-- **See relationships.** Blue rays point to the most closely related words; optional red dashed rays highlight a handful of very distant/contrasting words to give perspective.
-- **Explore by traveling.** Click any ray to “fly” to that word. The view re-centers there, showing its closest neighbors and a couple of contrasts. You can keep hopping, building an intuitive path through meaning.
-- **Always know your way back.** The word you came from remains one of the rays, so you can easily step back.
+## Features
+- **Live data** – pages and links are fetched on demand from the Wikipedia API (no pre‑computed files).
+- **Deterministic layout** – neighbour positions are derived from their titles so returning to a page looks the same.
+- **Return strand** – the page you came from is always included so you can hop back.
+- **Caching and throttling** – polite API usage and instant revisits.
+- **Wikipedia search** – type to search for any article and re‑centre on it.
 
-## What it’s for
-- **Sense-making:** Quickly grasp the semantic "neighborhood" around a term.
-- **Discovery:** Find adjacent concepts, unexpected bridges, and useful contrasts.
-- **Brainstorming & writing:** Generate alternatives, related themes, or oppositional angles.
-- **Learning:** Explore vocabulary relationally—how ideas cluster, diverge, and connect.
+## Running locally
+The project is a static site; any HTTP server will do:
 
-## How it behaves (user perspective)
-- The scene is clean and focused: one central word, its rays, and clickable labels—no cluttered cloud.
-- Similarity is visualized: closer/clearer blue rays ≈ stronger relationship; red dashed rays = deliberate opposites/outsiders for contrast.
-- Navigation feels physical: you move along a chosen connection, land, and a new star of meanings blooms around your destination.
-- The experience is repeatable: the same word shows the same pattern of connections, so you can retrace or share discoveries.
-
-## Run locally
 ```bash
-cd wordmap-starfield
 python3 -m http.server 8000
 # open http://localhost:8000
 ```
 
-## Deploy on GitHub Pages
-- Push this folder to a repo root (e.g., `main`).
-- Enable Pages for the root of `main` in repo settings.
-- Visit the URL GitHub gives you.
-
-## Files
-- `index.html` – app shell
-- `styles.css` – UI
-- `app.js` – Three.js starfield, camera travel, re-root logic
-- `data/` – toy dataset:
-  - `words.json` – admissible words
-  - `coords.json` – global 3-D coords per word (used only to orient rays deterministically)
-  - `nn.json` – top-K similar neighbors with cosine-like scores
-  - `far.json` – contrast picks (negative-ish scores)
-  - `freq.json` – fake frequency ranks for node size
-
-## Behavior
-- **No global cloud.** Only the current **star** renders.
-- **Travel along the clicked ray** (≈800ms), then re-root at the destination.
-- Always inject a **return strand** (previous center) if missing from top-K, so navigation is symmetric.
-- **Contrast rays** are dashed red; toggle via the checkbox.
-- Labels appear on hover and in the sidebar; click entries in the sidebar to travel too.
-
-## Swap in real data later
-Keep the same shapes for a zero-code swap:
-- `words.json` → `["apple","banana",...]`
-- `coords.json` → `{ "apple":[x,y,z], ... }`  (from your once-run global PCA→3D)
-- `nn.json` → `{ "apple":[["banana",0.78], ...], ... }` (K neighbors by cosine)
-- `far.json` → `{ "apple":[["thermodynamics",-0.41], ...], ... }` (C far/negative, e.g. NN on −v)
-- `freq.json` → `{ "apple": 134, ... }` (optional, for node size)
-
-No backend required.
+## Attribution
+Content from [Wikipedia](https://wikipedia.org) is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license.

--- a/app.js
+++ b/app.js
@@ -42,21 +42,9 @@ const tooltip = document.createElement('div');
 tooltip.className = 'tooltip';
 container.appendChild(tooltip);
 
-// ====== Data ======
-const params = new URLSearchParams(location.search);
-const DATA_BASE = params.get('data') || './data';
-
-let words = [];
-const coordsMap = new Map();
-const nnMap = new Map();
-const farMap = new Map();
-const freqMap = new Map();
-const wordSet = new Set();
-const starCache = new Map();
-
-// ====== Starfield groups (we only render the current star) ======
-let starGroup = new THREE.Group();      // center + neighbor nodes
-let edgeGroup = new THREE.Group();      // rays
+// ====== Star groups ======
+let starGroup = new THREE.Group();
+let edgeGroup = new THREE.Group();
 scene.add(starGroup);
 scene.add(edgeGroup);
 
@@ -79,17 +67,9 @@ const materialNeighborHover = new THREE.SpriteMaterial({
   blending: THREE.AdditiveBlending,
   transparent: true
 });
-
 const materialRayHover = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 1, linewidth: 2 });
-const materialRayContrastHover = new THREE.LineDashedMaterial({ color: 0xffffff, transparent: true, opacity: 1, dashSize: 1, gapSize: 0.5 });
 
-let showFar = true;
-document.getElementById('showFar').addEventListener('change', (e)=>{
-  showFar = e.target.checked;
-  if (currentWord) rebuildStar(currentWord, lastPrevWord, true);
-});
-
-// ====== Interactions ======
+// ====== Interaction ======
 const raycaster = new THREE.Raycaster();
 raycaster.params.Line.threshold = 0.1;
 const mouse = new THREE.Vector2();
@@ -102,94 +82,13 @@ container.addEventListener('mousemove', (e)=>{
 });
 
 container.addEventListener('click', ()=>{
-  if (hovered && hovered.object && hovered.object.userData && hovered.object.userData.word && hovered.object.userData.kind !== 'center') {
-    const toWord = hovered.object.userData.word;
-    travelToNeighbor(toWord);
+  if (hovered && hovered.object && hovered.object.userData && hovered.object.userData.title && hovered.object.userData.kind !== 'center') {
+    const toTitle = hovered.object.userData.title;
+    travelToNeighbor(toTitle);
   }
 });
 
-// ====== Load data and init ======
-async function init(){
-  const overlay = document.getElementById('loading');
-  try {
-    const loaders = ['words.json','coords.json','nn.json','far.json','freq.json'].map(f=>
-      fetch(`${DATA_BASE}/${f}`).then(r=>{ if(!r.ok) throw new Error(f); return r.json(); }).catch(()=>({__error:f}))
-    );
-    const metaPromise = fetch(`${DATA_BASE}/dataset_meta.json`).then(r=> r.ok ? r.json() : null).catch(()=>null);
-    const [wRes,cRes,nRes,fRes,frqRes,meta] = await Promise.all([...loaders, metaPromise]);
-
-    if (!wRes.__error) { words = wRes; words.forEach(w=>wordSet.add(w)); }
-    else showToast(`Failed to load ${wRes.__error}`);
-    if (!cRes.__error) { for(const [k,v] of Object.entries(cRes)) coordsMap.set(k,v); }
-    else showToast(`Failed to load ${cRes.__error}`);
-    if (!nRes.__error) { for(const [k,v] of Object.entries(nRes)) nnMap.set(k,v); }
-    else showToast(`Failed to load ${nRes.__error}`);
-    if (!fRes.__error) { for(const [k,v] of Object.entries(fRes)) farMap.set(k,v); }
-    else showToast(`Failed to load ${fRes.__error}`);
-    if (!frqRes.__error) { for(const [k,v] of Object.entries(frqRes)) freqMap.set(k, v); }
-    else showToast(`Failed to load ${frqRes.__error}`);
-
-    populateDatalist(words);
-    if (meta) renderMeta(meta);
-    document.getElementById('search').focus();
-    animate();
-  } catch (err) {
-    console.error('Initialization error:', err);
-    showToast('Failed to load dataset.');
-  } finally {
-    overlay.classList.add('hidden');
-  }
-}
-
-function renderMeta(meta){
-  const footer = document.getElementById('datasetMeta');
-  const parts = [];
-  if (meta.model) parts.push(meta.model);
-  if (meta.k) parts.push(`K=${meta.k}`);
-  if (meta.c) parts.push(`C=${meta.c}`);
-  if (meta.pca_seed) parts.push(`PCA seed=${meta.pca_seed}`);
-  footer.textContent = parts.length ? `Dataset: ${parts.join(' • ')}` : '';
-}
-
-function populateDatalist(list) {
-  const dl = document.getElementById('wordlist');
-  dl.innerHTML = '';
-  list.forEach(w => {
-    const opt = document.createElement('option');
-    opt.value = w;
-    dl.appendChild(opt);
-  });
-}
-
-// ====== Star building ======
-
-let currentWord = null;
-let lastPrevWord = null; // for "return strand"
-let wordToMesh = new Map(); // current star only
-
-// Ray distance parameters
-// Values tuned for a focused, readable star around the current word.
-const R_MIN = 8;             // closest rays
-const R_MAX = 40;            // farthest rays for similar
-const R_CONTRAST_MIN = 45;   // base radius for contrast rays
-const R_CONTRAST_MAX = 80;   // farthest contrast rays
-
-function clearGroup(g) {
-  while (g.children.length) g.remove(g.children.pop());
-}
-
-function cosineToRadius(cos) {
-  const t = Math.max(-1, Math.min(1, cos));
-  const u = (t + 1) / 2; // [-1,1] -> [0,1]
-  return R_MIN + (1 - u) * (R_MAX - R_MIN);
-}
-
-function contrastCosToRadius(cos) {
-  const t = Math.max(-1, Math.min(0, cos));
-  const u = -t; // 0..1
-  return R_CONTRAST_MIN + u * (R_CONTRAST_MAX - R_CONTRAST_MIN);
-}
-
+// ====== Utility ======
 function seededHash(str){
   let h = 2166136261 >>> 0;
   for (let i=0;i<str.length;i++){
@@ -199,167 +98,376 @@ function seededHash(str){
   return h >>> 0;
 }
 
-function directionBetween(ca, cb, aw, bw){
-  if (cb) {
-    const d = [cb[0]-ca[0], cb[1]-ca[1], cb[2]-ca[2]];
-    const len = Math.hypot(d[0],d[1],d[2]) || 1;
-    return [d[0]/len, d[1]/len, d[2]/len];
-  }
-  const h = seededHash(`${aw}:${bw}`);
+function directionFromTitle(title){
+  const h = seededHash(title);
   const theta = (h % 360) * Math.PI/180;
   const phi = ((h>>9)%360) * Math.PI/180;
   return [Math.cos(theta)*Math.sin(phi), Math.sin(theta)*Math.sin(phi), Math.cos(phi)];
 }
 
-function getStarData(word){
-  if (starCache.has(word)) {
-    const v = starCache.get(word);
-    starCache.delete(word);
-    starCache.set(word, v);
+function clearGroup(g){
+  while (g.children.length) g.remove(g.children.pop());
+}
+
+// ====== Wikipedia adapter ======
+const starCache = new Map();
+const MAX_CACHE = 64;
+let lastFetch = 0;
+const FETCH_DELAY = 250;
+
+async function wikiFetch(url){
+  const now = Date.now();
+  const wait = Math.max(0, lastFetch + FETCH_DELAY - now);
+  if (wait) await new Promise(r=>setTimeout(r, wait));
+  lastFetch = Date.now();
+  return fetch(url, { headers: { 'Api-User-Agent': 'StarWiki/1.0 (https://example.com)' } });
+}
+
+async function getPageStar(title){
+  title = title.trim();
+  if (starCache.has(title)) {
+    const v = starCache.get(title);
+    starCache.delete(title); starCache.set(title, v);
     return v;
   }
-  const center = coordsMap.get(word) || [0,0,0];
-  const simRaw = nnMap.get(word) || [];
-  const simList = simRaw.map(([nb, cos]) => {
-    const dir = directionBetween(center, coordsMap.get(nb), word, nb);
-    const r = cosineToRadius(typeof cos === 'number' ? cos : 0.1);
-    const pos = [dir[0]*r, dir[1]*r, dir[2]*r];
-    return { word: nb, cos, pos };
-  });
-  const farRaw = farMap.get(word) || [];
-  const farList = farRaw.map(([nb, cos]) => {
-    const dir = directionBetween(center, coordsMap.get(nb), word, nb);
-    const r = contrastCosToRadius(typeof cos === 'number' ? cos : -1);
-    const pos = [dir[0]*r, dir[1]*r, dir[2]*r];
-    return { word: nb, cos, pos };
-  });
-  const data = { simList, farList };
-  starCache.set(word, data);
-  if (starCache.size > 256) {
+  let cont;
+  const linksSet = new Set();
+  let pageid = null;
+  let canonical = null;
+  do {
+    const url = `https://en.wikipedia.org/w/api.php?action=query&prop=links&plnamespace=0&pllimit=max&redirects=1&origin=*&titles=${encodeURIComponent(title)}${cont ? `&plcontinue=${encodeURIComponent(cont)}`:''}&format=json`;
+    const res = await wikiFetch(url);
+    const data = await res.json();
+    const pages = data.query.pages;
+    const page = pages[Object.keys(pages)[0]];
+    canonical = page.title;
+    pageid = page.pageid;
+    if (page.links) {
+      for (const l of page.links) {
+        if (l.title !== canonical) linksSet.add(l.title);
+        if (linksSet.size >= 20) break;
+      }
+    }
+    cont = data.continue && data.continue.plcontinue;
+  } while (cont && linksSet.size < 20);
+
+  const neighbors = [...linksSet].sort((a,b)=>a.localeCompare(b)).slice(0,20);
+
+  let summaryData = null;
+  try {
+    const res = await wikiFetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(canonical)}`);
+    if (res.ok) summaryData = await res.json();
+  } catch {}
+
+  const star = {
+    center: {
+      title: canonical,
+      pageid,
+      summary: summaryData?.extract,
+      thumbnailUrl: summaryData?.thumbnail?.source
+    },
+    neighbors,
+    fetchedAt: Date.now()
+  };
+  starCache.set(canonical, star);
+  if (starCache.size > MAX_CACHE) {
     const first = starCache.keys().next().value;
     starCache.delete(first);
   }
-  return data;
+  return star;
 }
 
-function buildStarInto(centerWord, prevWord, gStar, gEdge, map){
-  // Center node at origin
-  const centerMesh = new THREE.Sprite(materialCenter.clone());
-  centerMesh.position.set(0,0,0);
-  centerMesh.scale.setScalar(2);
-  centerMesh.userData = { word: centerWord, kind: 'center', baseScale: 2 };
-  gStar.add(centerMesh);
-  map.set(centerWord, centerMesh);
+// ====== Star building ======
+let currentTitle = null;
+let lastPrevTitle = null; // for return strand
+let wordToMesh = new Map();
 
-  const base = getStarData(centerWord);
-  const simList = base.simList.map(s=>({ ...s }));
-  if (prevWord && !simList.some(s => s.word === prevWord)) {
-    const dir = directionBetween(coordsMap.get(centerWord) || [0,0,0], coordsMap.get(prevWord), centerWord, prevWord);
-    const r = cosineToRadius(0.42);
-    simList.unshift({ word: prevWord, cos: 0.42, pos: [dir[0]*r, dir[1]*r, dir[2]*r] });
-  }
+const R_MIN = 8;
+const R_MAX = 40;
 
-  simList.forEach(({word: nb, cos, pos}) => {
-    placeNeighbor(nb, pos, cos, gStar, map);
-    addPreviewStar(nb, pos, gStar);
-    drawRay(centerWord, nb, new THREE.Vector3(0,0,0), new THREE.Vector3(pos[0], pos[1], pos[2]), cos, 'similar', gEdge);
-  });
-
-  let farList = [];
-  if (showFar) {
-    farList = base.farList.slice(0,5);
-    farList.forEach(({word: nb, cos, pos}) => {
-      placeNeighbor(nb, pos, cos, gStar, map);
-      addPreviewStar(nb, pos, gStar);
-      drawRay(centerWord, nb, new THREE.Vector3(0,0,0), new THREE.Vector3(pos[0], pos[1], pos[2]), cos, 'contrast', gEdge);
-    });
-  }
-
-  return { simList, farList: base.farList };
+function positionForNeighbor(title, index, total){
+  const dir = directionFromTitle(title);
+  const r = R_MIN + (total <= 1 ? 0 : index/(total-1)) * (R_MAX - R_MIN);
+  return [dir[0]*r, dir[1]*r, dir[2]*r];
 }
 
-function rebuildStar(centerWord, prevWord=null, redrawOnly=false){
-  if (!redrawOnly) {
-    starGroup.children.forEach(ch => ch.layers.enable(0));
-    edgeGroup.children.forEach(ch => ch.layers.enable(0));
-  }
-  clearGroup(starGroup);
-  clearGroup(edgeGroup);
-  wordToMesh.clear();
-
-  const {simList, farList} = buildStarInto(centerWord, prevWord, starGroup, edgeGroup, wordToMesh);
-
-  updateSidebar(centerWord, simList.map(s=>[s.word,s.cos]), farList.map(s=>[s.word,s.cos]));
-
-  currentWord = centerWord;
-  lastPrevWord = prevWord || lastPrevWord || null;
-
-  controls.target.set(0,0,0);
-  fadeInGroups();
-
-  simList.forEach(s => getStarData(s.word));
+function opacityFromRank(rank, total){
+  const t = total <= 1 ? 0 : rank/(total-1);
+  return 0.25 + (1 - t) * 0.75;
 }
 
-function placeNeighbor(word, posArray, cos, group = starGroup, map = wordToMesh){
+function placeNeighbor(title, posArray, group = starGroup, map = wordToMesh){
   const mesh = new THREE.Sprite(materialNeighbor.clone());
   mesh.position.set(posArray[0], posArray[1], posArray[2]);
-  const sz = sizeFromFreq(freqMap.get(word));
-  mesh.userData = { word, cos, kind: 'neighbor', baseScale: sz };
-  mesh.scale.set(sz, sz, 1);
+  mesh.userData = { title, kind: 'neighbor', baseScale: 1.2 };
+  mesh.scale.set(1.2, 1.2, 1);
   group.add(mesh);
-  map.set(word, mesh);
+  map.set(title, mesh);
   return mesh;
 }
 
-function addPreviewStar(word, posArray, targetGroup = starGroup){
-  const data = getStarData(word);
-  const preview = new THREE.Group();
-  const scale = 0.25;
-  data.simList.slice(0,3).forEach(({word: nb, pos}) => {
-    const sp = new THREE.Sprite(materialNeighbor.clone());
-    sp.position.set(pos[0]*scale, pos[1]*scale, pos[2]*scale);
-    const sz = sizeFromFreq(freqMap.get(nb)) * 0.5;
-    sp.scale.set(sz, sz, 1);
-    if (sp.material && 'opacity' in sp.material) sp.material.opacity = 0.7;
-    preview.add(sp);
-
-    const lineGeo = new THREE.BufferGeometry().setFromPoints([
-      new THREE.Vector3(0,0,0),
-      new THREE.Vector3(pos[0]*scale, pos[1]*scale, pos[2]*scale)
-    ]);
-    const lineMat = new THREE.LineBasicMaterial({ color: 0x7aa2f7, transparent: true, opacity: 0.2, linewidth: 1 });
-    const line = new THREE.Line(lineGeo, lineMat);
-    preview.add(line);
-  });
-  preview.position.set(posArray[0], posArray[1], posArray[2]);
-  preview.userData = { kind: 'preview' };
-  targetGroup.add(preview);
-}
-
-function drawRay(centerWord, targetWord, startVec3, endVec3, cos, type, group = edgeGroup){
+function drawRay(centerTitle, targetTitle, startVec3, endVec3, rank, total, group = edgeGroup){
   const geo = new THREE.BufferGeometry().setFromPoints([startVec3, endVec3]);
-  const mat = (type === 'contrast')
-    ? new THREE.LineDashedMaterial({ color: 0xf7768e, transparent: true, opacity: 0.95, dashSize: 1, gapSize: 0.5 })
-    : new THREE.LineBasicMaterial({ color: 0x7aa2f7, transparent: true, opacity: opacityFromCosine(cos), linewidth: 2 });
+  const mat = new THREE.LineBasicMaterial({ color: 0x7aa2f7, transparent: true, opacity: opacityFromRank(rank, total), linewidth: 2 });
   const line = new THREE.Line(geo, mat);
-  if (type === 'contrast') line.computeLineDistances();
   const mid = startVec3.clone().add(endVec3).multiplyScalar(0.5);
-  line.userData = { center: centerWord, word: targetWord, type, cos, normalMat: mat, mid };
+  line.userData = { center: centerTitle, title: targetTitle, kind: 'ray', normalMat: mat, mid };
   group.add(line);
 }
 
-function sizeFromFreq(rank) {
-  if (!rank) return 1.0;
-  const t = Math.min(1, Math.max(0, (rank-1)/4999));
-  return 1.35 - 0.75*t;
+function buildStarInto(centerTitle, prevTitle, data, gStar, gEdge, map){
+  const centerMesh = new THREE.Sprite(materialCenter.clone());
+  centerMesh.position.set(0,0,0);
+  centerMesh.scale.setScalar(2);
+  centerMesh.userData = { title: centerTitle, kind: 'center', baseScale: 2 };
+  gStar.add(centerMesh);
+  map.set(centerTitle, centerMesh);
+
+  const neighbors = data.neighbors.slice(0,20);
+  if (prevTitle && !neighbors.includes(prevTitle)) {
+    neighbors.unshift(prevTitle);
+    if (neighbors.length > 20) neighbors.pop();
+  }
+
+  neighbors.forEach((nb, i) => {
+    const pos = positionForNeighbor(nb, i, neighbors.length);
+    placeNeighbor(nb, pos, gStar, map);
+    drawRay(centerTitle, nb, new THREE.Vector3(0,0,0), new THREE.Vector3(pos[0], pos[1], pos[2]), i, neighbors.length, gEdge);
+  });
+
+  updateSidebar(data.center, neighbors);
 }
 
-function opacityFromCosine(cos) {
-  const t = Math.max(-1, Math.min(1, cos));
-  const u = (t + 1) / 2;
-  return 0.25 + 0.75 * u;
+function rebuildStar(title, prevTitle=null){
+  const overlay = document.getElementById('loading');
+  const text = document.getElementById('loadingText');
+  text.textContent = `Loading ${title}…`;
+  overlay.classList.remove('hidden');
+  getPageStar(title).then(star => {
+    overlay.classList.add('hidden');
+    const canonical = star.center.title;
+    clearGroup(starGroup); clearGroup(edgeGroup); wordToMesh.clear();
+    buildStarInto(canonical, prevTitle, star, starGroup, edgeGroup, wordToMesh);
+    currentTitle = canonical;
+    lastPrevTitle = prevTitle || lastPrevTitle || null;
+    controls.target.set(0,0,0);
+    fadeInGroups();
+  }).catch(err => {
+    console.error(err);
+    overlay.classList.add('hidden');
+    showToast('Failed to load page.');
+  });
 }
 
+// ====== Travel ======
+let isAnimating = false;
+async function travelToNeighbor(targetTitle){
+  if (isAnimating || !currentTitle || !wordToMesh.has(targetTitle)) return;
+  isAnimating = true;
+
+  const from = new THREE.Vector3(0,0,0);
+  const to = wordToMesh.get(targetTitle).position.clone();
+
+  const overlay = document.getElementById('loading');
+  const text = document.getElementById('loadingText');
+  text.textContent = `Loading ${targetTitle}…`;
+  overlay.classList.remove('hidden');
+  let star;
+  try {
+    star = await getPageStar(targetTitle);
+  } catch (e) {
+    overlay.classList.add('hidden');
+    showToast('Failed to load page.');
+    isAnimating = false;
+    return;
+  }
+  overlay.classList.add('hidden');
+
+  const newStar = new THREE.Group();
+  const newEdge = new THREE.Group();
+  const newMap = new Map();
+  buildStarInto(star.center.title, currentTitle, star, newStar, newEdge, newMap);
+  newStar.position.copy(to);
+  newEdge.position.copy(to);
+  scene.add(newStar);
+  scene.add(newEdge);
+
+  newStar.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; obj.material.opacity = 0; obj.material.transparent = true; }});
+  newEdge.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; obj.material.opacity = 0; obj.material.transparent = true; }});
+  starGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; }});
+  edgeGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; }});
+
+  const startCam = camera.position.clone();
+  const startTarget = controls.target.clone();
+  const startOffset = startCam.clone().sub(startTarget);
+  const endOffset = startOffset.clone().setLength(12);
+  const duration = 1400;
+  const fadeStart = 0.3;
+  const t0 = performance.now();
+  function tick(now){
+    const t = Math.min(1, (now - t0) / duration);
+    const ease = t < 0.5 ? 4*t*t*t : 1 - Math.pow(-2*t+2, 3)/2;
+
+    const curTarget = from.clone().lerp(to, ease);
+    controls.target.copy(curTarget);
+
+    const curOffset = startOffset.clone().lerp(endOffset, ease);
+    const curCam = curTarget.clone().add(curOffset);
+    camera.position.copy(curCam);
+
+    const fadeOut = t < fadeStart ? 1 : 1 - (t - fadeStart)/(1 - fadeStart);
+    const fadeIn = t < fadeStart ? 0 : (t - fadeStart)/(1 - fadeStart);
+
+    starGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeOut; }});
+    edgeGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeOut; }});
+    newStar.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeIn; }});
+    newEdge.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeIn; }});
+
+    renderOnce();
+
+    if (t < 1) requestAnimationFrame(tick);
+    else {
+      scene.remove(starGroup); scene.remove(edgeGroup);
+      newStar.position.sub(to); newEdge.position.sub(to);
+      starGroup = newStar;
+      edgeGroup = newEdge;
+      wordToMesh = newMap;
+      currentTitle = star.center.title;
+      lastPrevTitle = targetTitle;
+      controls.target.set(0,0,0);
+      camera.position.copy(endOffset);
+      hovered = null;
+      tooltip.classList.remove('show');
+      isAnimating = false;
+    }
+  }
+  requestAnimationFrame(tick);
+}
+
+// ====== Sidebar ======
+function updateSidebar(center, neighbors){
+  const heading = document.getElementById('currentWord');
+  heading.textContent = center.title;
+
+  const summaryDiv = document.getElementById('summary');
+  summaryDiv.innerHTML = '';
+  if (center.thumbnailUrl) {
+    const img = document.createElement('img');
+    img.src = center.thumbnailUrl;
+    img.alt = '';
+    summaryDiv.appendChild(img);
+  }
+  if (center.summary) {
+    const p = document.createElement('p');
+    p.textContent = center.summary;
+    summaryDiv.appendChild(p);
+  }
+  const link = document.createElement('a');
+  link.href = `https://en.wikipedia.org/wiki/${encodeURIComponent(center.title)}`;
+  link.target = '_blank';
+  link.textContent = 'View on Wikipedia';
+  summaryDiv.appendChild(link);
+
+  const container = document.getElementById('neighbors');
+  container.innerHTML = '';
+  neighbors.forEach(nb => {
+    const row = document.createElement('div');
+    row.className = 'item';
+    row.textContent = nb;
+    row.addEventListener('click', ()=> travelToNeighbor(nb));
+    container.appendChild(row);
+  });
+  if (neighbors.length === 0) {
+    const row = document.createElement('div');
+    row.className = 'hint';
+    row.textContent = 'No links found';
+    container.appendChild(row);
+  }
+}
+
+// ====== Hover ======
+function resetHovered(){
+  if (!hovered) return;
+  const obj = hovered.object;
+  if (obj.userData.kind === 'neighbor') {
+    obj.material = materialNeighbor.clone();
+    if(obj.userData.baseScale) obj.scale.set(obj.userData.baseScale, obj.userData.baseScale, 1);
+  } else if (obj.userData.normalMat) {
+    obj.material = obj.userData.normalMat;
+  }
+}
+
+function updateHover(){
+  raycaster.setFromCamera(mouse, camera);
+  const intersects = raycaster.intersectObjects([...edgeGroup.children, ...starGroup.children], false);
+  if (intersects.length > 0) {
+    const first = intersects[0];
+    if (hovered && hovered.object !== first.object) {
+      resetHovered();
+    }
+    hovered = first;
+    const obj = first.object;
+    tooltip.classList.add('show');
+    if (obj.userData.kind === 'neighbor') {
+      obj.material = materialNeighborHover.clone();
+      if(obj.userData.baseScale) obj.scale.set(obj.userData.baseScale * 1.25, obj.userData.baseScale * 1.25, 1);
+      const v = obj.position.clone().project(camera);
+      const x = (v.x * 0.5 + 0.5) * renderer.domElement.clientWidth;
+      const y = (-v.y * 0.5 + 0.5) * renderer.domElement.clientHeight;
+      tooltip.style.left = x + 'px';
+      tooltip.style.top = y + 'px';
+      tooltip.textContent = obj.userData.title;
+    } else if (obj.userData.title && obj.userData.kind !== 'center') {
+      obj.material = materialRayHover;
+      const v = obj.userData.mid.clone().project(camera);
+      const x = (v.x * 0.5 + 0.5) * renderer.domElement.clientWidth;
+      const y = (-v.y * 0.5 + 0.5) * renderer.domElement.clientHeight;
+      tooltip.style.left = x + 'px';
+      tooltip.style.top = y + 'px';
+      tooltip.textContent = obj.userData.title;
+    }
+  } else {
+    if (hovered) resetHovered();
+    hovered = null;
+    tooltip.classList.remove('show');
+  }
+}
+
+// ====== Search ======
+const searchInput = document.getElementById('search');
+let suggestTimer = null;
+searchInput.addEventListener('input', (e)=>{
+  clearTimeout(suggestTimer);
+  const q = e.target.value.trim();
+  if (!q) { populateDatalist([]); return; }
+  suggestTimer = setTimeout(async ()=>{
+    try {
+      const res = await wikiFetch(`https://en.wikipedia.org/w/api.php?action=opensearch&origin=*&limit=10&namespace=0&format=json&search=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      populateDatalist(data[1] || []);
+    } catch{}
+  }, 300);
+});
+
+function populateDatalist(list){
+  const dl = document.getElementById('wordlist');
+  dl.innerHTML = '';
+  list.forEach(w => {
+    const opt = document.createElement('option');
+    opt.value = w;
+    dl.appendChild(opt);
+  });
+}
+
+document.getElementById('goBtn').addEventListener('click', onGo);
+searchInput.addEventListener('keydown', (e)=>{ if (e.key === 'Enter') onGo(); });
+function onGo(){
+  const val = searchInput.value.trim();
+  if (!val) return;
+  rebuildStar(val, currentTitle);
+}
+
+// ====== Animation ======
 function fadeInGroups(){
   starGroup.traverse(obj => {
     if(obj.material && 'opacity' in obj.material){
@@ -397,187 +505,6 @@ function fadeInGroups(){
   requestAnimationFrame(tick);
 }
 
-// Sidebar
-function updateSidebar(center, simList, farList){
-  const container = document.getElementById('neighbors');
-  container.innerHTML = '';
-
-  const simCard = document.createElement('div');
-  simCard.className = 'card';
-  simCard.innerHTML = '<h3>Similar</h3>';
-  simList.forEach(([nb, cos]) => {
-    const row = document.createElement('div');
-    row.className = 'item';
-    const left = document.createElement('span'); left.textContent = nb;
-    const right = document.createElement('span'); right.className = 'badge';
-    right.textContent = (typeof cos === 'number' ? cos.toFixed(2) : '—');
-    row.appendChild(left); row.appendChild(right);
-    row.addEventListener('click', ()=> travelToNeighbor(nb));
-    simCard.appendChild(row);
-  });
-  container.appendChild(simCard);
-
-  if (showFar && farList.length) {
-    const farCard = document.createElement('div');
-    farCard.className = 'card';
-    farCard.innerHTML = '<h3>Contrast</h3>';
-    farList.forEach(([nb, cos]) => {
-      const row = document.createElement('div');
-      row.className = 'item';
-      const left = document.createElement('span'); left.textContent = nb;
-      const right = document.createElement('span'); right.className = 'badge';
-      right.textContent = (typeof cos === 'number' ? cos.toFixed(2) : '—');
-      row.appendChild(left); row.appendChild(right);
-      row.addEventListener('click', ()=> travelToNeighbor(nb));
-      farCard.appendChild(row);
-    });
-    container.appendChild(farCard);
-  }
-
-  document.getElementById('currentWord').textContent = center;
-}
-
-// Travel: animate along the chosen ray, then re-root
-let isAnimating = false;
-function travelToNeighbor(targetWord){
-  if (isAnimating || !currentWord || !wordToMesh.has(targetWord)) return;
-  isAnimating = true;
-
-  const from = new THREE.Vector3(0,0,0);
-  const to = wordToMesh.get(targetWord).position.clone();
-
-  const newStar = new THREE.Group();
-  const newEdge = new THREE.Group();
-  const newMap = new Map();
-  const {simList, farList} = buildStarInto(targetWord, currentWord, newStar, newEdge, newMap);
-  newStar.position.copy(to);
-  newEdge.position.copy(to);
-  scene.add(newStar);
-  scene.add(newEdge);
-
-  newStar.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; obj.material.opacity = 0; obj.material.transparent = true; }});
-  newEdge.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; obj.material.opacity = 0; obj.material.transparent = true; }});
-  starGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; }});
-  edgeGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.userData.baseOpacity = obj.material.opacity; }});
-
-  const startCam = camera.position.clone();
-  const startTarget = controls.target.clone();
-  const startOffset = startCam.clone().sub(startTarget);
-  const endOffset = startOffset.clone().setLength(12);
-
-  const duration = 1400;
-  const fadeStart = 0.3;
-
-  const t0 = performance.now();
-  function tick(now){
-    const t = Math.min(1, (now - t0) / duration);
-    const ease = t < 0.5 ? 4*t*t*t : 1 - Math.pow(-2*t+2, 3)/2;
-
-    const curTarget = from.clone().lerp(to, ease);
-    controls.target.copy(curTarget);
-
-    const curOffset = startOffset.clone().lerp(endOffset, ease);
-    const curCam = curTarget.clone().add(curOffset);
-    camera.position.copy(curCam);
-
-    const fadeOut = t < fadeStart ? 1 : 1 - (t - fadeStart)/(1 - fadeStart);
-    const fadeIn = t < fadeStart ? 0 : (t - fadeStart)/(1 - fadeStart);
-
-    starGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeOut; }});
-    edgeGroup.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeOut; }});
-    newStar.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeIn; }});
-    newEdge.traverse(obj => { if(obj.material && 'opacity' in obj.material){ obj.material.opacity = obj.userData.baseOpacity * fadeIn; }});
-
-    renderOnce();
-
-    if (t < 1) requestAnimationFrame(tick);
-    else {
-      scene.remove(starGroup); scene.remove(edgeGroup);
-      newStar.position.sub(to); newEdge.position.sub(to);
-      starGroup = newStar;
-      edgeGroup = newEdge;
-      wordToMesh = newMap;
-      updateSidebar(targetWord, simList.map(s=>[s.word,s.cos]), farList.map(s=>[s.word,s.cos]));
-      lastPrevWord = currentWord;
-      currentWord = targetWord;
-      controls.target.set(0,0,0);
-      camera.position.copy(endOffset);
-      simList.forEach(s => getStarData(s.word));
-      hovered = null;
-      tooltip.classList.remove('show');
-      isAnimating = false;
-    }
-  }
-  requestAnimationFrame(tick);
-}
-
-// Hover + tooltip
-function resetHovered(){
-  if (!hovered || !hovered.object) return;
-  const obj = hovered.object;
-  if (obj.userData.kind === 'neighbor') {
-    obj.material = materialNeighbor.clone();
-    if(obj.userData.baseScale) obj.scale.set(obj.userData.baseScale, obj.userData.baseScale, 1);
-  } else if (obj.userData.normalMat) {
-    obj.material = obj.userData.normalMat;
-  }
-}
-
-function updateHover(){
-  raycaster.setFromCamera(mouse, camera);
-  const intersects = raycaster.intersectObjects([...edgeGroup.children, ...starGroup.children], false);
-  if (intersects.length > 0) {
-    const first = intersects[0];
-    if (hovered && hovered.object !== first.object) {
-      resetHovered();
-    }
-    hovered = first;
-    const obj = first.object;
-    tooltip.classList.add('show');
-    if (obj.userData.kind === 'neighbor') {
-      obj.material = materialNeighborHover.clone();
-      if(obj.userData.baseScale) obj.scale.set(obj.userData.baseScale * 1.25, obj.userData.baseScale * 1.25, 1);
-      const v = obj.position.clone().project(camera);
-      const x = (v.x * 0.5 + 0.5) * renderer.domElement.clientWidth;
-      const y = (-v.y * 0.5 + 0.5) * renderer.domElement.clientHeight;
-      tooltip.style.left = x + 'px';
-      tooltip.style.top = y + 'px';
-      tooltip.textContent = obj.userData.word;
-    } else if (obj.userData.word && obj.userData.kind !== 'center') {
-      obj.material = obj.userData.type === 'contrast' ? materialRayContrastHover : materialRayHover;
-      const v = obj.userData.mid.clone().project(camera);
-      const x = (v.x * 0.5 + 0.5) * renderer.domElement.clientWidth;
-      const y = (-v.y * 0.5 + 0.5) * renderer.domElement.clientHeight;
-      tooltip.style.left = x + 'px';
-      tooltip.style.top = y + 'px';
-      tooltip.textContent = obj.userData.word;
-    }
-  } else {
-    if (hovered) resetHovered();
-    hovered = null;
-    tooltip.classList.remove('show');
-  }
-}
-
-// Search handlers
-document.getElementById('goBtn').addEventListener('click', onGo);
-document.getElementById('search').addEventListener('keydown', (e)=>{ if (e.key === 'Enter') onGo(); });
-function onGo(){
-  const val = document.getElementById('search').value.trim().toLowerCase();
-  if (!val) return;
-  if (!wordSet.has(val)) {
-    showToast('Word not in dataset.');
-    return;
-  }
-  if (!currentWord) {
-    rebuildStar(val);
-  } else {
-    if (wordToMesh.has(val)) travelToNeighbor(val);
-    else rebuildStar(val, currentWord);
-  }
-}
-
-// Render loop
 function animate(){
   requestAnimationFrame(animate);
   controls.update();
@@ -603,9 +530,14 @@ function showToast(msg){
   setTimeout(()=> t.classList.remove('show'), 2500);
 }
 
+function init(){
+  document.getElementById('loading').classList.add('hidden');
+  animate();
+}
+
 init();
 
-// helper to generate distant static stars
+// ====== Helpers ======
 function createBackgroundStars(){
   const count = 1000;
   const positions = new Float32Array(count * 3);

--- a/index.html
+++ b/index.html
@@ -3,36 +3,32 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>WordSpace • Semantic Starfield</title>
+    <title>StarWiki • Wikipedia Rabbit Hole Explorer</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div id="loading" class="overlay"><span id="loadingText">Loading dataset…</span></div>
+    <div id="loading" class="overlay"><span id="loadingText">Loading…</span></div>
     <header>
-      <h1>WordSpace • Semantic Starfield</h1>
+      <h1>StarWiki • Wikipedia Rabbit Hole Explorer</h1>
       <div class="controls">
-        <input id="search" type="text" placeholder="Type a word to center (e.g., apple)" list="wordlist" />
+        <input id="search" type="text" placeholder="Type a page title (e.g., Earth)" list="wordlist" />
         <datalist id="wordlist"></datalist>
         <button id="goBtn">Re-center</button>
-        <label class="toggle"><input id="showFar" type="checkbox" checked /> Contrast rays</label>
-      </div>
-      <div class="legend">
-        <span class="dot similar"></span> Blue rays = related words
-        <span class="dot contrast"></span> Red dashed rays = distant contrasts
       </div>
     </header>
 
     <main>
       <div id="canvas"></div>
       <aside id="info">
-        <h2 id="currentWord">Select a word</h2>
-        <div class="hint">Hover a ray to see its word; click to travel. Scroll to zoom. Drag to orbit.</div>
+        <h2 id="currentWord">Select a page</h2>
+        <div id="summary"></div>
+        <div class="hint">Hover a ray to see its title; click to travel. Scroll to zoom. Drag to orbit.</div>
         <div id="neighbors"></div>
       </aside>
     </main>
 
     <footer>
-      <small id="datasetMeta"></small>
+      <small>Content from <a href="https://wikipedia.org" target="_blank">Wikipedia</a> • CC BY-SA 4.0</small>
     </footer>
 
     <div id="toast" class="toast"></div>

--- a/styles.css
+++ b/styles.css
@@ -21,12 +21,9 @@ header h1 { margin:0 12px 0 0; font-size:18px; color:var(--accent); }
 .controls button { padding:8px 12px; border:none; border-radius:8px; background:var(--accent); color:#0b1020; font-weight:600; cursor:pointer; transition:background 0.2s, transform 0.1s; }
 .controls button:hover { background:#96bdfc; }
 .controls button:active { transform:scale(0.97); }
-.controls .toggle { font-size:12px; color:var(--muted); display:flex; align-items:center; gap:6px; }
 
-.legend { font-size:12px; color:var(--muted); display:flex; gap:16px; align-items:center; }
-.legend .dot { width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px; }
-.legend .similar { background: var(--accent); }
-.legend .contrast { background: var(--danger); }
+#summary { font-size:13px; color:var(--muted); margin-bottom:8px; }
+#summary img { width:100%; max-height:120px; object-fit:cover; border-radius:6px; margin-bottom:6px; }
 
 main { display:grid; grid-template-columns: 1fr 300px; height: calc(100vh - 70px); }
 #canvas { position:relative; background:radial-gradient(circle at center, #0c0e17, #05060b); }


### PR DESCRIPTION
## Summary
- replace precomputed word dataset with live Wikipedia API adapter and LRU caching
- draw up to twenty outgoing article links per page and include return strand for navigation
- add search suggestions, summary sidebar and CC BY-SA attribution

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d11580a083299c4bab13e4cbcb4a