### PR TITLE
Add return strand and reset search sessions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,7 @@ main { display:grid; grid-template-columns: 1fr 300px; height: calc(100vh - 110p
 .neighbor { display:flex; gap:6px; align-items:flex-start; padding:6px; background:var(--panel); border:1px solid #23283b; border-radius:8px; cursor:pointer; }
 .neighbor:focus { outline:2px solid var(--accent); }
 .neighbor.visited { opacity:0.6; }
+.neighbor.return { border-color:var(--danger); color:var(--danger); justify-content:center; align-items:center; }
 .neighbor .thumb { width:40px; height:40px; object-fit:cover; border-radius:4px; background:#23283b; flex-shrink:0; }
 .neighbor .meta { flex:1; overflow:hidden; }
 .neighbor .title { font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }


### PR DESCRIPTION
## Summary
- Draw a red return strand to the previously centered page, including a special node when needed
- Pin a "Back to" entry in the sidebar for quick returning
- Searching starts a fresh session, clearing caches, history, and settings

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68a39e89bba08329a58fe413aa7e7609