### PR TITLE
Add keyboard hop history, trail mode, and sharable URL support

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <label class="toggle"><input type="checkbox" id="backToggle" /> Backlinks
           <span class="info-icon">ℹ️<span class="info-text">Show pages that link back to the current page.</span></span>
         </label>
+        <label class="toggle"><input type="checkbox" id="trailToggle" checked /> Trail</label>
         <button id="resetCam" title="Reset camera">🏠 Reset Camera</button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Add history tracking with left/right arrow navigation and animated hops
- Introduce Trail Mode to keep faded ghost clusters and path lines
- Sync center, mode, and trail settings to URL for shareable links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a96d85888329bbb4ff5e27928961