### PR TITLE
Add history navigation and red return edge

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,7 @@ footer { padding:6px 12px; border-top:1px solid #23283b; font-size:12px; color:v
 #breadcrumbs { display:flex; gap:6px; flex-wrap:wrap; padding:6px 16px; background:#0f1220; border-bottom:1px solid #23283b; font-size:12px; }
 #breadcrumbs button { background:none; border:none; color:var(--accent); cursor:pointer; padding:2px 4px; border-radius:4px; max-width:120px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 #breadcrumbs button:hover, #breadcrumbs button:focus { background:#23283b; outline:none; }
+#breadcrumbs button.active { background:#23283b; color:var(--text); }
 #breadcrumbs span { color:var(--muted); }
 
 .overlay { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(14,15,19,0.9); display:flex; align-items:center; justify-content:center; z-index:50; font-size:20px; }


### PR DESCRIPTION
## Summary
- Track visited pages in a history stack with active index and highlight the current breadcrumb
- Allow left/right arrow navigation through history, closing modals and animating between pages
- Always draw a red return edge to the previous step in the chain

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b941c62c83298c1bdff18d078d5a