### PR TITLE
Ensure sidebar content fits within width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -29,9 +29,9 @@ header h1 { margin:0 12px 0 0; font-size:18px; color:var(--accent); }
 #summary { font-size:13px; color:var(--muted); margin-bottom:8px; }
 #summary img { width:100%; max-height:120px; object-fit:cover; border-radius:6px; margin-bottom:6px; }
 
-main { display:grid; grid-template-columns: 1fr 330px; height: calc(100vh - 110px); }
+main { display:grid; grid-template-columns: 1fr clamp(260px, 30%, 330px); height: calc(100vh - 110px); }
 #canvas { position:relative; background:radial-gradient(circle at center, #0c0e17, #05060b); }
-#info { border-left:1px solid #23283b; padding:12px; background:#0f1220; overflow-y:auto; overflow-x:hidden; box-shadow:-2px 0 4px rgba(0,0,0,0.4); }
+#info { border-left:1px solid #23283b; padding:12px; background:#0f1220; overflow-y:auto; overflow-x:hidden; box-shadow:-2px 0 4px rgba(0,0,0,0.4); max-width:100%; }
 #info * { max-width:100%; }
 #currentWord, #summary { overflow-wrap:anywhere; }
 #currentWord { margin:6px 0 8px; font-size:16px; }
@@ -52,6 +52,7 @@ main { display:grid; grid-template-columns: 1fr 330px; height: calc(100vh - 110p
   color:var(--muted);
   white-space:normal;
   overflow-wrap:anywhere;
+  word-break:break-word;
 }
 .neighbor .ext { margin-left:4px; color:var(--muted); text-decoration:none; }
 .neighbor .ext:hover { color:var(--accent); }
@@ -93,7 +94,7 @@ footer { padding:6px 12px; border-top:1px solid #23283b; font-size:12px; color:v
   .preview-body h3 { margin:0 0 6px; font-size:16px; }
   .preview-content { display:flex; gap:8px; }
   .preview-content img { width:60px; height:60px; object-fit:cover; border-radius:4px; background:#23283b; flex-shrink:0; }
-  .preview-content p { margin:0; font-size:13px; color:var(--muted); }
+  .preview-content p { margin:0; font-size:13px; color:var(--muted); overflow-wrap:anywhere; word-break:break-word; }
   .attrib { font-size:11px; color:var(--muted); margin-top:6px; }
   .preview-link { display:block; margin-top:8px; font-size:13px; color:var(--accent); text-decoration:none; }
   .preview-link:hover { text-decoration:underline; }


### PR DESCRIPTION
## Summary
- Clamp sidebar column width to prevent overflow and add max-width so sidebar shrinks with the window
- Wrap neighbor preview text and modal excerpts so long strings stay inside the panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c228ad2c8329a751114a0452ea33