### PR TITLE
feat: add trail mode with ghost clusters

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <label class="toggle"><input type="checkbox" id="backToggle" /> Backlinks
           <span class="info-icon">ℹ️<span class="info-text">Show pages that link back to the current page.</span></span>
         </label>
+        <label class="toggle"><input type="checkbox" id="trailToggle" checked /> Trail</label>
         <button id="resetCam" title="Reset camera">🏠 Reset Camera</button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add Trail Mode with ghost clusters and persistent center trail
- keep latest N ghosts with fade and non-interactive behavior
- add UI toggle for Trail Mode and camera reset to current center

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cee335b48329986f92f9cffa78d6