### PR TITLE
Fix backlinks toggle not updating cluster

### DIFF
--- a/app.js
+++ b/app.js
@@ -431,7 +431,10 @@ function rebuildStar(title, addToHistory=true){
       history[historyIndex] = canonical;
     }
     clusterGroups.forEach(g=>{ scene.remove(g.star); scene.remove(g.edge); });
-    clearGroup(starGroup); clearGroup(edgeGroup); wordToMesh.clear();
+    clearGroup(starGroup); clearGroup(edgeGroup);
+    // Ensure the reusable groups are attached to the scene again
+    scene.add(starGroup); scene.add(edgeGroup);
+    wordToMesh.clear();
     clusterGroups.clear(); centerPositions.clear(); ghostQueue.length = 0;
     trailGeometry.setFromPoints([]);
     buildStarInto(canonical, star, starGroup, edgeGroup, wordToMesh);


### PR DESCRIPTION
## Summary
- Reattach reusable star and edge groups to the Three.js scene when rebuilding
- Ensure toggling Backlinks immediately shows backlink star cluster

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d64dd710832995d4a9286a0c1555